### PR TITLE
Update to autosar 2022

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Available features:
 - Generate SHE Memory update protocol messages (M1 M2 M3 M4 M5).
 - Parse M1 M2 Memory update protocol messages in order to get the update information.
 
+## Disclaimer
+
+Vector's related specification specifies different layout of `flags` - it uses 5 flags instead of 6, described in AUTOSAR specs as this repo fully follows. Please adjust script accordingly then, I would be glad to some PR propositions if you have anything working. Enjoy!
+
 ## Prerequisites
 
 With using Python greater than 3.8 install package to your environment.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Available features:
 
 ## Prerequisites
 
-With using Python 3.8, 3.9 or 3.10 install package to your environment.
+With using Python greater than 3.8 install package to your environment.
 
 ```bash
 pip install SecureHardwareExtension
@@ -81,7 +81,9 @@ update_protocol.update_info.new_key
 
 ## Sources
 
-[Autosar specification](https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf)
+Accessed 26.07.2025.
+
+[Autosar specification](https://www.autosar.org/fileadmin/standards/R22-11/FO/AUTOSAR_TR_SecureHardwareExtensions.pdf)
 
 [NXP application note](https://www.nxp.com/docs/en/application-note/AN4234.pdf)
 

--- a/secure_hardware_extension/constants.py
+++ b/secure_hardware_extension/constants.py
@@ -24,7 +24,7 @@ class classproperty:
 class SheConstants:
     """
     Class holds constants used within SHE.
-    https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf
+    https://www.autosar.org/fileadmin/standards/R22-11/FO/AUTOSAR_TR_SecureHardwareExtensions.pdf
     4.12 Constants used with SHE.
 
     """

--- a/secure_hardware_extension/key_slots/autosar.py
+++ b/secure_hardware_extension/key_slots/autosar.py
@@ -13,7 +13,7 @@ class AutosarKeySlots(KeySlots):
     """
     Enum holds memory slot identification based on
     `Specification of Secure Hardware Extensions, AUTOSAR FO R19-11`.
-    https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf
+    https://www.autosar.org/fileadmin/standards/R22-11/FO/AUTOSAR_TR_SecureHardwareExtensions.pdf
 
     """
 

--- a/secure_hardware_extension/memory_update.py
+++ b/secure_hardware_extension/memory_update.py
@@ -135,7 +135,7 @@ class MemoryUpdateProtocol:
     @property
     def m2(self):
         cid = (self.update_info.counter & 0xFFFFFFF) << 100
-        fid = (self.update_info.fid & 0b111111) << 95
+        fid = (self.update_info.fid & 0b111111) << 94
         plain = (cid + fid).to_bytes(16, byteorder="big") + self.update_info.new_key
         return AES.new(self.k1, AES.MODE_CBC, iv=she_bytes.fromhex("00" * 16)).encrypt(
             plain

--- a/secure_hardware_extension/memory_update.py
+++ b/secure_hardware_extension/memory_update.py
@@ -135,7 +135,7 @@ class MemoryUpdateProtocol:
     @property
     def m2(self):
         cid = (self.update_info.counter & 0xFFFFFFF) << 100
-        fid = (self.update_info.fid & 0b111111) << 94
+        fid = (self.update_info.fid & 0b111111) << 95
         plain = (cid + fid).to_bytes(16, byteorder="big") + self.update_info.new_key
         return AES.new(self.k1, AES.MODE_CBC, iv=she_bytes.fromhex("00" * 16)).encrypt(
             plain

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ readme = (root_directory / "README.md").read_text()
 
 setup(
     name="SecureHardwareExtension",
-    version="1.0.0",
+    version="1.0.1",
     install_requires=[
         "pycryptodome",
     ],
@@ -22,6 +22,9 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/tests/unit_tests/test_memory_update.py
+++ b/tests/unit_tests/test_memory_update.py
@@ -1,6 +1,6 @@
 """
 Test vectors found in 
-https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf
+https://www.autosar.org/fileadmin/standards/R22-11/FO/AUTOSAR_TR_SecureHardwareExtensions.pdf
 
 """
 


### PR DESCRIPTION
Refreshed with new AUTOSAR spec version released.
According to the comment in one the issues, `M2` might be badly generated.
Therefore, doublechecked with new specs which actually has same test vectors - seems correct.